### PR TITLE
ensure machine_options and configs are symbolised for chef13

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -42,6 +42,18 @@ module ChefProvisioningVsphere
         ] : h
     end
 
+    def deep_symbolize(hash_like)
+      if hash_like.nil? || hash_like.empty?
+        return {}
+      end
+      r = {}
+      hash_like.each do |key, value|
+        value = deep_symbolize(value) if value.respond_to?(:values)
+        r[key.to_sym] = value
+      end
+      r
+    end
+
     def initialize(driver_url, config)
       super(driver_url, config)
 
@@ -110,6 +122,7 @@ module ChefProvisioningVsphere
     #           -- vm_folder: name of the vSphere folder containing the VM
     #
     def allocate_machine(action_handler, machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
 
       if machine_spec.location
@@ -146,9 +159,10 @@ module ChefProvisioningVsphere
 
     def merge_options!(machine_options)
       @config = Cheffish::MergedConfig.new(
-        { machine_options: machine_options },
+        { :machine_options => machine_options },
         @config
       )
+      @config=deep_symbolize(@config.to_h)
     end
 
     def add_machine_spec_location(vm, machine_spec)
@@ -202,6 +216,7 @@ module ChefProvisioningVsphere
     end
 
     def ready_machine(action_handler, machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
 
       vm = start_machine(action_handler, machine_spec, machine_options)
@@ -393,11 +408,13 @@ module ChefProvisioningVsphere
 
     # Connect to machine without acquiring it
     def connect_to_machine(machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
       machine_for(machine_spec, machine_options)
     end
 
     def destroy_machine(action_handler, machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
       vm = vm_for(machine_spec)
       if vm
@@ -417,6 +434,7 @@ module ChefProvisioningVsphere
     end
 
     def stop_machine(action_handler, machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
       vm = vm_for(machine_spec)
       if vm
@@ -427,6 +445,7 @@ module ChefProvisioningVsphere
     end
 
     def start_machine(action_handler, machine_spec, machine_options)
+      machine_options=deep_symbolize(machine_options)
       merge_options! machine_options
       vm = vm_for(machine_spec)
       if vm


### PR DESCRIPTION
This is required to work with cheffish5 and cheffish13.  Also requires a seperate patch which is in a pull request for chef provisioning itself, but with these two we're provisioning on chef 13 reliably