### PR TITLE
Updated some depenant gems

### DIFF
--- a/chef-provisioning-vsphere.gemspec
+++ b/chef-provisioning-vsphere.gemspec
@@ -21,11 +21,18 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files -z`.split("\x0")
   s.test_files   = s.files.grep(%r{^(test|spec|features)/})
 
-  s.add_dependency 'rbvmomi', '~> 1.8.0', '>= 1.8.2'
-  s.add_dependency 'chef-provisioning', '~>2.0', '>= 2.0.1'
+  s.add_dependency 'rbvmomi', '~> 1.10'
+  s.add_dependency 'chef-provisioning', '~> 2.0'
   s.add_dependency 'github_changelog_generator'
+  s.add_dependency 'chef', '~> 12'
+  s.add_dependency 'cheffish', '~> 4'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'chefstyle'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'pry-stack_explorer'
+  s.add_development_dependency 'rb-readline'
+
 end


### PR DESCRIPTION
- Updated rbvmomi
- Updated chef-provisioning
- Pinned to version chef 12
- pinned version of cheffish
- added debug gems

The chef 12 and cheffish pinning is due to the cheffish 5 release and
chef-provisioning lagging behind. As soon as it's released and fixed we
will retest with Chef 13 and Cheffish 5.

Signed-off-by: JJ Asghar <jj@chef.io>