### PR TITLE
Revert "Wait for ipv4 enhancement"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,7 +53,7 @@ Metrics/BlockNesting:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 699
+  Max: 599
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:
@@ -63,7 +63,7 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 300
+  Max: 189
 
 # Offense count: 40
 # Configuration parameters: CountComments.


### PR DESCRIPTION
Reverts chef-partners/chef-provisioning-vsphere#14

I need to revert this for the time being, it seems it never gets out of the "IP address found" stage:

```
[2017-04-27T13:11:40-05:00] INFO: Processing chef_node[testing-ready] action create (basic_chef_client::block line 57)

    - Power on VM [vm/testing-ready][2017-04-27T13:11:40-05:00] INFO: 70168522646360 Executing sudo pwd on admini@

    -
    Waiting up to 300 seconds for customization
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]

[-- snip --]

    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - IP addresses found: ["172.16.20.153", "fe80::250:56ff:fe8a:d11"]
    - rebooting...
    - Shutdown guest OS and power off VM [vm/testing-ready]
    - Power on VM [vm/testing-ready]
    - restart machine testing-ready (vsphere://172.16.20.2/sdk?use_ssl=true&insecure=true)

```

More testing is going to be needed.