### PR TITLE
corrected winrm port assignment so it does not always equal 5986

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -686,7 +686,7 @@ module ChefProvisioningVsphere
       require 'chef/provisioning/transport/winrm'
       winrm_transport =
         options[:winrm_transport].nil? ? :negotiate : options[:winrm_transport].to_sym
-      port = options[:port] || winrm_transport == :ssl ? '5986' : '5985'
+      port = options[:port] || (winrm_transport == :ssl ? '5986' : '5985')
       winrm_options = {
         user: (options[:user]).to_s,
         pass: options[:password]


### PR DESCRIPTION
Testing revealed that if a winrm port was specified that it was ignored and the port assignment line always resulted with 5986. By adding parenthesis, this has corrected the issue by forcing proper order of operations.