### PR TITLE
Traverse folders for dc (issue #23)

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
+++ b/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
@@ -85,16 +85,16 @@ module ChefProvisioningVsphere
     end
 
     def traverse_folders_for_dc(folder, dcname)
-        children = folder.children.find_all
-        children.each do |child|
-          if child.class == RbVmomi::VIM::Datacenter && child.name == dcname
-            return child
-          elsif child.class == RbVmomi::VIM::Folder
-            dc = traverse_folders_for_dc(child, dcname)
-            return dc if dc
-          end
+      children = folder.children.find_all
+      children.each do |child|
+        if child.class == RbVmomi::VIM::Datacenter && child.name == dcname
+          return child
+        elsif child.class == RbVmomi::VIM::Folder
+          dc = traverse_folders_for_dc(child, dcname)
+          return dc if dc
         end
-        false
+      end
+      false
     end
 
     def datacenter


### PR DESCRIPTION
This code snippet facilitates finding data centers within folders and was unit tested. It is originally based on the code in knife vsphere. 

I was unable to test the gem through chef as I'm not sure how to do that. Hopefully someone else is more comfortable with it or advise on how I can do it.
