### PR TITLE
Handle blank guest IP address that generates multiple different errors.

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -925,7 +925,7 @@ module ChefProvisioningVsphere
         @vm_helper.ip = vm.guest.ipAddress if vm_guest_ip?(vm)
         start_search_ip = false if @vm_helper.open_port?(@vm_helper.ip, @vm_helper.port, 1)
       end
-      raise "Timed out waiting for ipv4 address!" if tries > max_tries && !IPAddr.new(vm.guest.ipAddress).ipv4?
+      raise "Timed out waiting for ipv4 address!" if tries > max_tries
       puts "Found ipv4 address!"
       true
     end

--- a/lib/chef/provisioning/vsphere_driver/vm_helper.rb
+++ b/lib/chef/provisioning/vsphere_driver/vm_helper.rb
@@ -57,6 +57,7 @@ module ChefProvisioningVsphere
     # @param [Integer] timeout The number of seconds before timeout.
     # @return [true] Returns true when the socket is available to connect.
     def open_port?(host, port, timeout = 5)
+      return false if host.to_s.empty?
       true if ::Socket.tcp(host, port, connect_timeout: timeout)
     rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH
       false


### PR DESCRIPTION
### Description
On some setups the guest IP address being returned is blank and this causes various errors including:
- `connect(2) for "0.0.0.0" port 5985 (0.0.0.0:5985)`
- `Address family must be specified`

### Issues Resolved
This should resolve the following issues:
Issue 35 - Failing to test WinRM availability when creating vm (https://github.com/chef-partners/chef-provisioning-vsphere/issues/35)

### Check List

- [X] All tests pass.
- [X] All style checks pass.
- [X] Functionality includes testing.
- [X] Functionality has been documented in the README if applicable
