### PR TITLE
add initial_iso_image to support deployment from custom iso images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         docker {
             args "-u root"
                 reuseNode false
-                image "localhost:5000/jjkeysv3"
+                image "localhost:5000/jjkeysv5"
                 }
     }
     triggers {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ for i in recipes/*; do sed -i 's/PASSWORD/Good4bye!/g' "$i"; done
 sed -i 's/PASSWORD/Good4bye!/g' .kitchen.yml
 sed -i 's/ORG/jj-model-t/g' recipes/windows_provision.rb
 chef exec bundle install
+chef exec gem install test-kitchen
 chef exec bundle exec kitchen list'''
       }
     }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:host]` - `{cluster}`/`{host}` to use during provisioning
 - `[:resource_pool]` - `{cluster}`/`{resource pool}` to use during provisioning
 - `[:additional_disk_size_gb]` - an array of numbers, each signifying the number of gigabytes to assign to an additional disk (*this requires a datastore to be specified*)
+- `[:initial_iso_file]` - an iso file to mount at boot.  This is useful for custom OS installations.  In the format of `[datastore] filename.iso`
 - `[:bootstrap_ipv4]` - `true` / `false`, set to `true` to wait for an IPv4 address to become available before bootstrapping.
 - `[:ipv4_timeout]` - use with `[:bootstrap_ipv4]`, set the time in seconds to wait before an IPv4 address is received (defaults to 30)
 - `[:ssh][:user]` user to use for ssh/winrm (defaults to root on linux/administrator on windows)

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -702,6 +702,28 @@ module ChefProvisioningVsphere
         task.wait_for_completion
       end
 
+      if bootstrap_options[:initial_iso_image]
+        d_obj = vm.config.hardware.device.select {|hw| hw.class == RbVmomi::VIM::VirtualCdrom}.first
+        backing = RbVmomi::VIM::VirtualCdromIsoBackingInfo(fileName: bootstrap_options[:initial_iso_image])
+        task = vm.ReconfigVM_Task(
+          spec: RbVmomi::VIM.VirtualMachineConfigSpec(
+            deviceChange: [
+              operation: :edit,
+              device: RbVmomi::VIM::VirtualCdrom(
+                backing: backing,
+                key: d_obj.key,
+                controllerKey: d_obj.controllerKey,
+                connectable: RbVmomi::VIM::VirtualDeviceConnectInfo(
+                  startConnected: true,
+                  connected: true,
+                  allowGuestControl: true)
+                )
+              ]
+            )
+          )
+          task.wait_for_completion
+      end
+
       vm
     end
 


### PR DESCRIPTION
adds a parameter :initial_iso_image to bootstrap_options to allow attaching a boot iso (we have a use case where we generate custom ISOs for OS's that don't support vmware customization)

