### PR TITLE
Solve #59: action :destroy fails on powered off VM

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
+++ b/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
@@ -79,6 +79,7 @@ module ChefProvisioningVsphere
     # @param [Object] timeout Defaults to 600 seconds or 10 mins before giving up.
     def stop_vm(vm, timeout = 600)
       start = Time.now.utc
+      return if vm.runtime.powerState == "poweredOff"
       begin
         vm.ShutdownGuest
         until (Time.now.utc - start) > timeout ||


### PR DESCRIPTION

### Description

A quick fix where we check that a VM isn't powered off before shutting it down. 

### Issues Resolved

 [#59](https://github.com/chef-partners/chef-provisioning-vsphere/issues/59)

### Check List

Not really tested since there is just one line of code added, but it fixed my problem.
