### PR TITLE
ready_timeout fix without breaking previous work

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -889,8 +889,14 @@ module ChefProvisioningVsphere
         else
           ## Check if true available
           vm_ip = bootstrap_options[:customization_spec][:ipsettings][:ip] unless vm_helper.ip?
+          # TODO: please create a better solution for the below
+          # bootstrap_options shouldn't contain the :ready_timeout value - machine_options does
+          # however, I don't want to break previous work or change all the calls made to this function
+          # setting a default, as for most people bootstrap_options[:ready_timeout] will be nil
+          # another possible workaround is to add a second entry under bootstrap_options in .kitchen.yml
+          ready_timeout = bootstrap_options[:ready_timeout] || 90
           nb_attempts = 0
-          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > bootstrap_options[:ready_timeout]
+          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > ready_timeout
             print '.'
             nb_attempts += 1
           end


### PR DESCRIPTION
### Description

According to the documentation, the .kitchen.yml file contains the :ready_timeout parameter under machine_options directly - not bootstrap_options. Because bootstrap_options is passed to the ip_to_bootstrap function, :ready_timeout is not visible.

### Issues Resolved

The commit https://github.com/chef-partners/chef-provisioning-vsphere/commit/0040fb83809f7ed2d0723c1dc4020f984e8c450a essentially broke mine (and I'm guessing others who are following the doc's standard for the .kitchen.yml file). Added a variable that gets passed the :ready_timeout, but in case it's nil it will default to 90 so as to no longer break.

### Check List

- [/] All tests pass.
- [/] All style checks pass.
- [/] Functionality includes testing.
- [/] Functionality has been documented in the README if applicable
