### PR TITLE
Ready timeout fix

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -889,11 +889,6 @@ module ChefProvisioningVsphere
         else
           ## Check if true available
           vm_ip = bootstrap_options[:customization_spec][:ipsettings][:ip] unless vm_helper.ip?
-          # TODO: please create a better solution for the below
-          # bootstrap_options shouldn't contain the :ready_timeout value - machine_options does
-          # however, I don't want to break previous work or change all the calls made to this function
-          # setting a default, as for most people bootstrap_options[:ready_timeout] will be nil
-          # another possible workaround is to add a second entry under bootstrap_options in .kitchen.yml
           ready_timeout = bootstrap_options[:ready_timeout] || 90
           nb_attempts = 0
           until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > ready_timeout

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -889,8 +889,14 @@ module ChefProvisioningVsphere
         else
           ## Check if true available
           vm_ip = bootstrap_options[:customization_spec][:ipsettings][:ip] unless vm_helper.ip?
+          # TODO: please create a better solution for the below
+          # bootstrap_options shouldn't contain the :ready_timeout value - machine_options does
+          # however, I don't want to break previous work or change all the calls made to this function
+          # setting a default, as for most people bootstrap_options[:ready_timeout] will be nil
+          # another possible workaround is to add a second entry under bootstrap_options in .kitchen.yml
+          ready_timeout = bootstrap_options[:ready_timeout] || 90
           nb_attempts = 0
-          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > bootstrap_options[:ready_timeout]
+          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > ready_timeout
             print '.'
             nb_attempts += 1
           end

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -889,9 +889,8 @@ module ChefProvisioningVsphere
         else
           ## Check if true available
           vm_ip = bootstrap_options[:customization_spec][:ipsettings][:ip] unless vm_helper.ip?
-          ready_timeout = bootstrap_options[:ready_timeout] || 90
           nb_attempts = 0
-          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > ready_timeout
+          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || (nb_attempts > (bootstrap_options[:ready_timeout] || 90))
             print '.'
             nb_attempts += 1
           end


### PR DESCRIPTION
### Description

According to the documentation, the .kitchen.yml file contains the :ready_timeout parameter under machine_options directly - not bootstrap_options. Because bootstrap_options is passed to the ip_to_bootstrap function, :ready_timeout is not visible.

          # TODO: please create a better solution for the below
          # bootstrap_options shouldn't contain the :ready_timeout value - machine_options does
          # however, I don't want to break previous work or change all the calls made to this function
          # setting a default, as for most people bootstrap_options[:ready_timeout] will be nil
          # another possible workaround is to add a second entry under bootstrap_options in .kitchen.yml


### Issues Resolved

The commit https://github.com/chef-partners/chef-provisioning-vsphere/commit/0040fb83809f7ed2d0723c1dc4020f984e8c450a essentially broke mine (and I'm guessing others who are following the doc's standard for the .kitchen.yml file). Added an OR comparison to essentially assign the value of 90 in case bootoptions[:ready_timeout] resolves to nil so as to no longer break.

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
