### PR TITLE
fixed bootstrap ready timeout call

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -890,7 +890,7 @@ module ChefProvisioningVsphere
           ## Check if true available
           vm_ip = bootstrap_options[:customization_spec][:ipsettings][:ip] unless vm_helper.ip?
           nb_attempts = 0
-          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || nb_attempts > bootstrap_options[:ready_timeout]
+          until @vm_helper.open_port?(vm_ip, @vm_helper.port, 1) || (nb_attempts > (bootstrap_options[:ready_timeout] || 90))
             print '.'
             nb_attempts += 1
           end


### PR DESCRIPTION
### Description

According to the documentation, the .kitchen.yml file contains the :ready_timeout parameter under machine_options directly - not bootstrap_options. Because bootstrap_options is passed to the ip_to_bootstrap function, :ready_timeout is not visible.

      # TODO: please create a better solution for the below
      # bootstrap_options shouldn't contain the :ready_timeout value - machine_options does
      # however, I don't want to break previous work or change all the calls made to this function
      # setting a default, as for most people bootstrap_options[:ready_timeout] will be nil
      # another possible workaround is to add a second entry under bootstrap_options in .kitchen.yml


### Issues Resolved

The commit 0040fb8 essentially broke mine (and I'm guessing others who are following the doc's standard for the .kitchen.yml file). Added an OR comparison to essentially assign the value of 90 in case bootoptions[:ready_timeout] resolves to nil so as to no longer break.

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
