### PR TITLE
Handle IPv6 address returned by VM

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,7 +52,7 @@ Metrics/BlockNesting:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 638
+  Max: 643
 
 # Offense count: 11
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A vCenter and valid login credentials.
 
 ### VM Template
 
-A VM template capable of installing Chef 11.8 or newer. This can be either windows or linux flavored.
+A VM template capable of installing Chef 11.8 or newer. This can be either windows or linux flavored. Both IPv4 and IPv6 are supported.
 
 ### A provisioning node (can be local)
 

--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -847,8 +847,13 @@ module ChefProvisioningVsphere
       else
         winrm_options.merge!(options[:winrm_opts])
       end
-      endpoint = "http#{winrm_transport == :ssl ? 's' : ''}://"\
-                 "#{host}:#{port}/wsman"
+      scheme = winrm_transport == :ssl ? 'https' : 'http'
+      endpoint = URI::Generic.build(
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: '/wsman'
+      ).to_s
 
       Chef::Provisioning::Transport::WinRM.new(
         endpoint,


### PR DESCRIPTION
### Description

Prevents this error message when running `kitchen create`:

    ------Exception-------
    Class: Kitchen::ActionFailed
    Message: 1 actions failed.
        Failed to complete #create action: [bad URI(is not URI?): http://caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78:5985/wsman] on the-vm-name
    ----------------------
    Please see .kitchen/logs/kitchen.log for more details
    Also try running `kitchen diagnose --all` for configuration

The URI

    http://caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78:5985/wsman

should have brackets around the IPv6 address, like this:

    http://[caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78]:5985/wsman

### Issues Resolved

https://github.com/chef-partners/chef-provisioning-vsphere/issues/52

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [ ] Functionality includes testing.

    Raising an exception where the modification is causes no tests to fail, so I could not find a convenient place to add a new test.  Sorry.

- [x] Functionality has been documented in the README if applicable
