### PR TITLE
Save VM properties to kitchen state file after cloning

### DIFF
--- a/spec/integration_tests/vsphere_driver_spec.rb
+++ b/spec/integration_tests/vsphere_driver_spec.rb
@@ -36,6 +36,8 @@ require 'chef/provisioning/machine_spec'
 
 describe 'vsphere_driver' do
   before :all do
+    skip("driver options do not exist") unless File.exist?(File.expand_path('../config.rb', __FILE__))
+
     @vm_name = "cmvd-test-#{SecureRandom.hex}"
     @metal_config = eval File.read(File.expand_path('../config.rb', __FILE__))
     Cheffish.honor_local_mode do


### PR DESCRIPTION
### Description

- Uses the `vsphere_name` from the kitchen state file if it exists. Otherwise, generates a new VM name.
- Store the VM properties after cloning (`add_machine_spec_location`), rather than at the end of `clone_vm` because adding disks, or mounting an iso could raise an error
- Validate `additional_volumes` once 

### Issues Resolved

#53 

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
