### PR TITLE
Fix bug where ip address is not returned from guest tools

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/vm_helper.rb
+++ b/lib/chef/provisioning/vsphere_driver/vm_helper.rb
@@ -17,12 +17,6 @@ module ChefProvisioningVsphere
       Timeout::Error, IPAddr::AddressFamilyError
     ].freeze
 
-    # If the IP is true
-    #
-    def ip?
-      @ip
-    end
-
     # If the port is true
     #
     def port?

--- a/spec/unit_tests/VsphereDriver_spec.rb
+++ b/spec/unit_tests/VsphereDriver_spec.rb
@@ -130,4 +130,94 @@ describe ChefProvisioningVsphere::VsphereDriver do
       end
     end
   end
+
+  context "#ip_to_bootstrap" do
+    let(:metal_config) { {} }
+    let(:vm) { double("vm") }
+    let(:vm_helper) do
+      double("vm_helper")
+    end
+    before do
+      allow_any_instance_of(Kernel).to receive(:print)
+    end
+
+    before do
+      allow(subject).to receive(:vm_helper).and_return(vm_helper)
+
+      allow(vm_helper).to receive(:find_port?)
+      allow(vm_helper).to receive(:port?)
+      allow(vm_helper).to receive(:port).and_return(port)
+    end
+
+    let(:port) { 22 }
+    let(:bootstrap_conf) { {} }
+    
+    context "has_static_ip" do
+      let(:bootstrap_conf) { { customization_spec: "some spec" } }
+      context "customization_spec is named" do
+        let(:vsphere_helper) { double("vsphere_helper") }
+        let(:fake_spec) { double("fake_spec") }
+        let(:fake_adapter) { double("fake_adapter") }
+        let(:fake_ip) do
+          RbVmomi::VIM::CustomizationFixedIp(
+            ipAddress: "1.1.1.1"
+          )
+        end
+
+        it "return ip address" do
+          allow(subject).to receive(:vsphere_helper).and_return(vsphere_helper)
+          allow(fake_adapter).to receive_message_chain(:adapter, :ip).and_return(fake_ip)
+          allow(fake_spec).to receive(:nicSettingMap).and_return([fake_adapter])
+          allow(vsphere_helper).to receive(:find_customization_spec).and_return(fake_spec)
+          allow(vm_helper).to receive(:open_port?).with("1.1.1.1", port, 1).and_return(true)
+
+          result = subject.send :ip_to_bootstrap, bootstrap_conf, vm
+          expect(result).to eq "1.1.1.1"
+        end
+      end
+
+      context "customization_spec has an ip address" do
+        let(:bootstrap_conf) do
+          { 
+            customization_spec: {
+              ipsettings: {
+                ip: "2.2.2.2"
+              }
+            } 
+          }
+        end
+
+        it "returns ip address" do
+          allow(vm_helper).to receive(:ip?)
+          allow(vm_helper).to receive(:open_port?).with("2.2.2.2", port, 1).and_return(true)
+          result = subject.send :ip_to_bootstrap, bootstrap_conf, vm
+          expect(result).to eq "2.2.2.2"
+        end
+      end
+    end
+
+    context "use_ipv4_during_bootstrap" do
+      let(:bootstrap_conf) { { bootstrap_ipv4: true } }
+
+      it "returns ip address" do
+        allow(subject).to receive(:wait_for_ipv4).and_return("3.3.3.3")
+        allow(vm_helper).to receive(:open_port?).with("3.3.3.3", port, 1).and_return(true)
+
+        result = subject.send :ip_to_bootstrap, bootstrap_conf, vm
+        expect(result).to eq "3.3.3.3"
+      end
+    end
+
+    context "wait until guest tools returns an IP address" do
+      it "returns ip address" do
+        allow_any_instance_of(Kernel).to receive(:sleep)
+        expect(subject).to receive(:vm_guest_ip?).exactly(3).times.and_return(false, false, true)
+        allow(vm).to receive_message_chain(:guest, :ipAddress).and_return("4.4.4.4")
+
+        allow(vm_helper).to receive(:open_port?).exactly(1).times.with("4.4.4.4", port, 1).and_return(true)
+        result = subject.send :ip_to_bootstrap, bootstrap_conf, vm
+        expect(result).to eq "4.4.4.4"
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description

There's a bug where the ip address is not returned from the guest tools properly.
This causes the connectivity test to fail, because its trying to connect to ip address `nil`.

### Check List

- [x] All tests pass.
- [ ] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
