### PR TITLE
Fix missing_method deprecation from Cheffish::MergedConfig

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -56,7 +56,8 @@ module ChefProvisioningVsphere
     #
     # @param [Object] hash_like converts to key:value
     def deep_symbolize(hash_like)
-      return {} if hash_like.nil? || hash_like.empty?
+      return {} if hash_like.nil?
+
       r = {}
       hash_like.each do |key, value|
         value = deep_symbolize(value) if value.respond_to?(:values)

--- a/spec/unit_tests/VsphereDriver_spec.rb
+++ b/spec/unit_tests/VsphereDriver_spec.rb
@@ -220,4 +220,42 @@ describe ChefProvisioningVsphere::VsphereDriver do
       end
     end
   end
+
+  context "#merge_options!" do
+    let(:metal_config) { {} }
+
+    it "Add tupple with string key" do
+      subject.merge_options! "string_key" => "some string"
+      expect(subject.config).to eq machine_options: {
+        string_key: "some string",
+      }
+    end
+
+    it "Add tupple with symbol key" do
+      subject.merge_options! symbol_key: "some other string"
+      expect(subject.config).to eq machine_options: {
+        symbol_key: "some other string",
+      }
+    end
+
+    it "Add empty MergedConfig" do
+      expect($stderr).not_to receive(:puts)
+
+      item = Cheffish::MergedConfig.new()
+      subject.merge_options! item
+
+      expect(subject.config).to eq machine_options: {}
+    end
+
+    it "Add MergedConfig with 1 tupple" do
+      expect($stderr).not_to receive(:puts)
+
+      item = Cheffish::MergedConfig.new(merged_config: "some merged value")
+      subject.merge_options! item
+
+      expect(subject.config).to eq machine_options: {
+        merged_config: "some merged value",
+      }
+    end
+  end
 end


### PR DESCRIPTION
### Description

This fixes the deprecation warning coming from `Cheffish::MergedConfig`

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
