### PR TITLE
Support NSX Logical Switch created by NSX-T

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
+++ b/lib/chef/provisioning/vsphere_driver/vsphere_helpers.rb
@@ -403,6 +403,11 @@ module ChefProvisioningVsphere
         RbVmomi::VIM::VirtualEthernetCardDistributedVirtualPortBackingInfo(
           port: port
         )
+      elsif network.is_a? RbVmomi::VIM::OpaqueNetwork
+        RbVmomi::VIM::VirtualEthernetCardOpaqueNetworkBackingInfo(
+          opaqueNetworkType: network.summary.opaqueNetworkType,
+          opaqueNetworkId: network.summary.opaqueNetworkId
+        )
       else
         RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(
           deviceName: network_name.split("/").last


### PR DESCRIPTION
This enhancement is for recognizing NSX Logical Switch created by NSX-T.
Otherwise when a NSX Logical Switch is specified as the network name, it won't find it and create a new Logical Switch with the same name. However, VMs connected to this new Logical Switch cannot get DHCP IP.