### PR TITLE
Fix issue when checking guest IP of the VM with Docker installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This will use chef-zero and needs no chef server (only works for ssh). Note that
 - `[:bootstrap_ipv4]` - `true` / `false`, set to `true` to wait for an IPv4 address to become available before bootstrapping.
 - `[:ipv4_timeout]` - use with `[:bootstrap_ipv4]`, set the time in seconds to wait before an IPv4 address is received (defaults to 30)
 - `[:ip_ready_timeout]` - set the time in seconds to wait before the machine IP is ready and connectable (defaults to 300)
+- `[:invalid_ip_prefix]` - set the invalid prefix of the machine IP, e.g. the docker NIC IP like 172.17.0.1 (defaults to `nil` and can be set to something like '172.17')
 - `[:ssh][:user]` user to use for ssh/winrm (defaults to root on linux/administrator on windows)
 - `[:ssh][:password]` - password to use for ssh/winrm
 - `[:ssh][:paranoid]` - specifies the strictness of the host key verification checking


### PR DESCRIPTION
When docker daemon runs in the VM, there will be a NIC created by
Docker and usually has IP like 172.17.x.x. When VM is booting up,
VM Tools sometimes reports this IP to vCenter, although the real IP
of the non-docker nic will be reported later.

This patch can filter out the docker IP by specifying the prefix of
the invalid machine IP via the bootstrap option 'invalid_ip_prefix'.
e.g. invalid_ip_prefix: '172.17'.